### PR TITLE
Adding pandas and xlsxwriter to reqs + Fix date in PasswordSpray detection

### DIFF
--- a/Requirements.txt
+++ b/Requirements.txt
@@ -1,2 +1,8 @@
-netaddr
 evtx
+netaddr
+numpy
+pandas
+python-dateutil
+pytz
+six
+XlsxWriter

--- a/lib/EvtxDetection.py
+++ b/lib/EvtxDetection.py
@@ -1084,7 +1084,7 @@ def detect_events_security_log(file_name):
     for user in PasswordSpray:
         if len(PasswordSpray[user])>3:
             Event_desc = "Password Spray Detected by user ( "+user+" )"
-            Security_events[0]['Date and Time'].append(datetime.now())
+            Security_events[0]['Date and Time'].append(record["timestamp"])
             Security_events[0]['Detection Rule'].append("Password Spray Detected")
             Security_events[0]['Detection Domain'].append("Threat")
             Security_events[0]['Severity'].append("High")


### PR DESCRIPTION
When launching a dry run, I noticed some libraries were missing. This PR adds them in the requirements.txt.

It also adds a fix for the PasswordSpray detection which used to use `datetime.now` instead of the actual date in the log file.