### PR TITLE
Update requirements.txt: missing flatten_json

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ python-dateutil
 pytz
 six
 XlsxWriter
+flatten_json


### PR DESCRIPTION
Hello,

I just add the dependency flatten_json which is imported in `lib/SigmaHunter.py`.
<img width="1077" alt="image" src="https://github.com/ahmedkhlief/APT-Hunter/assets/28646904/583cc80f-78f0-4dad-b650-2ef6cd0b9773">
<img width="771" alt="image" src="https://github.com/ahmedkhlief/APT-Hunter/assets/28646904/786cc33e-1016-4b0f-bfad-0b69d38179fa">


Regards,