### PR TITLE
GitHub Action to lint Python code

### DIFF
--- a/.github/workflows/codespell_and_ruff.yml
+++ b/.github/workflows/codespell_and_ruff.yml
@@ -1,0 +1,23 @@
+# This Action uses minimal steps to run in ~5 seconds to rapidly:
+# look for typos in the codebase using codespell, and
+# lint Python code using ruff and provide intuitive GitHub Annotations to contributors.
+# https://github.com/codespell-project/codespell#readme
+# https://docs.astral.sh/ruff/
+name: codespell_and_ruff
+on:
+  push:
+    # branches: [main, master]
+  pull_request:
+    # branches: [main, master]
+jobs:
+  codespell_and_ruff:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v4
+    - run: pip install --user codespell[toml] ruff
+    - run: codespell || true  # --ignore-words-list="" --skip="*.css,*.js,*.lock,*.po"
+    - run: ruff check --output-format=github --select=E9,F63,F7 --target-version=py38 .
+    - run: ruff check --output-format=github --select=E9,F63,F7,F82 --target-version=py38 .
+    - run: ruff check --output-format=github --line-length=200 --target-version=py38 .
+    - run: ruff check --output-format=github --target-version=py38 .
+    - run: ruff check --output-format=github

--- a/.github/workflows/codespell_and_ruff.yml
+++ b/.github/workflows/codespell_and_ruff.yml
@@ -15,9 +15,5 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - run: pip install --user codespell[toml] ruff
-    - run: codespell || true  # --ignore-words-list="" --skip="*.css,*.js,*.lock,*.po"
-    - run: ruff check --output-format=github --select=E9,F63,F7 --target-version=py38 .
-    - run: ruff check --output-format=github --select=E9,F63,F7,F82 --target-version=py38 .
+    - run: codespell --skip="*.css,*.json" || true  # --ignore-words-list=""
     - run: ruff check --output-format=github --line-length=200 --target-version=py38 .
-    - run: ruff check --output-format=github --target-version=py38 .
-    - run: ruff check --output-format=github

--- a/.github/workflows/codespell_and_ruff.yml
+++ b/.github/workflows/codespell_and_ruff.yml
@@ -15,5 +15,5 @@ jobs:
     steps:
     - uses: actions/checkout@v4
     - run: pip install --user codespell[toml] ruff
-    - run: codespell --skip="*.css,*.json" || true  # --ignore-words-list=""
+    - run: codespell --skip="*.csv,*.json" || true  # --ignore-words-list=""
     - run: ruff check --output-format=github --line-length=200 --target-version=py38 .


### PR DESCRIPTION
## Test output: https://github.com/cclauss/APT-Hunter/actions

This Action uses minimal steps to run in ~5 seconds to rapidly:
* look for typos in the codebase using codespell, and
* lint Python code using ruff and provide intuitive GitHub Annotations to contributors.

https://github.com/codespell-project/codespell#readme

https://docs.astral.sh/ruff